### PR TITLE
Bug when inside cellloader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,11 @@
 			<artifactId>java-scpclient</artifactId>
 			<version>0.0.2-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>sc.fiji</groupId>
+			<artifactId>bigdataviewer-vistools</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<distributionManagement>
 		<repository>

--- a/src/test/java/test/RotateSingleDataset.java
+++ b/src/test/java/test/RotateSingleDataset.java
@@ -1,0 +1,55 @@
+
+package test;
+
+import cz.it4i.parallel.TestParadigm;
+import io.scif.services.DatasetIOService;
+import net.imagej.Dataset;
+import net.imagej.plugins.commands.imglib.RotateImageXY;
+import org.scijava.Context;
+import org.scijava.parallel.ParallelizationParadigm;
+import org.scijava.ui.UIService;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RotateSingleDataset
+{
+
+	public static void main(String[] args) throws IOException
+	{
+		Context context = new Context();
+		DatasetIOService ioService = context.service( DatasetIOService.class );
+		UIService uiService = context.service( UIService.class );
+		try( ParallelizationParadigm paradigm = TestParadigm.localImageJServer( Config.getFijiExecutable(), context ))
+		{
+			uiService.show( rotateSingleDataset( ioService, paradigm ) );
+		}
+	}
+
+	static Object rotateSingleDataset( DatasetIOService ioService, ParallelizationParadigm paradigm )
+	{
+		List< Map< String, Object > > parametersList = initParameters(ioService);
+		List<Map<String, Object>> results = paradigm.runAll(RotateImageXY.class,
+				parametersList);
+		return results.get( 0 ).get( "dataset" );
+	}
+
+	private static List< Map< String, Object > > initParameters( DatasetIOService ioService )
+	{
+		try
+		{
+			Dataset dataset = ioService.open( ExampleImage.lenaAsTempFile().toString());
+			Map<String, Object> parameters = new HashMap<>();
+			parameters.put("dataset", dataset);
+			parameters.put("angle", 90);
+			return Collections.singletonList(parameters);
+		}
+		catch ( IOException e )
+		{
+			throw new RuntimeException( e );
+		}
+	}
+}

--- a/src/test/java/test/RotateSingleDataset.java
+++ b/src/test/java/test/RotateSingleDataset.java
@@ -1,13 +1,7 @@
 
 package test;
 
-import cz.it4i.parallel.TestParadigm;
 import io.scif.services.DatasetIOService;
-import net.imagej.Dataset;
-import net.imagej.plugins.commands.imglib.RotateImageXY;
-import org.scijava.Context;
-import org.scijava.parallel.ParallelizationParadigm;
-import org.scijava.ui.UIService;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -15,10 +9,19 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.imagej.Dataset;
+import net.imagej.plugins.commands.imglib.RotateImageXY;
+
+import org.scijava.Context;
+import org.scijava.parallel.ParallelizationParadigm;
+import org.scijava.ui.UIService;
+
+import cz.it4i.parallel.TestParadigm;
+
 public class RotateSingleDataset
 {
 
-	public static void main(String[] args) throws IOException
+	public static void main(String[] args)
 	{
 		Context context = new Context();
 		DatasetIOService ioService = context.service( DatasetIOService.class );

--- a/src/test/java/test/ScriptEvalRemotely.java
+++ b/src/test/java/test/ScriptEvalRemotely.java
@@ -19,15 +19,20 @@ public class ScriptEvalRemotely {
 		final ImageJ ij = new ImageJ();
 		ij.ui().showUI();
 		try( ParallelizationParadigm paradigm = TestParadigm.localImageJServer( Config.getFijiExecutable(), ij.context() )) {
-			List<Map<String, Object>> paramsList = new LinkedList<>();
-			for (int i = 0; i < 10; i++) {
-				Map<String, Object> params = new HashMap<>();
-				params.put("language", "ij1");
-				params.put("script", "print('hello from script" + i +
-						"'); getDirectory('home'); exec('whoami');");
-				paramsList.add(params);
-			}
-			paradigm.runAll("net.imagej.server.external.ScriptEval", paramsList);
+			run( paradigm );
 		}
+	}
+
+	static void run( ParallelizationParadigm paradigm )
+	{
+		List<Map<String, Object>> paramsList = new LinkedList<>();
+		for (int i = 0; i < 10; i++) {
+			Map<String, Object> params = new HashMap<>();
+			params.put("language", "ij1");
+			params.put("script", "print('hello from script" + i +
+					"'); getDirectory('home'); exec('whoami');");
+			paramsList.add(params);
+		}
+		paradigm.runAll("net.imagej.server.external.ScriptEval", paramsList);
 	}
 }

--- a/src/test/java/test/SimpleExampleInDiskCachedCellImg.java
+++ b/src/test/java/test/SimpleExampleInDiskCachedCellImg.java
@@ -1,0 +1,40 @@
+package test;
+
+import bdv.util.BdvFunctions;
+import cz.it4i.parallel.TestParadigm;
+import io.scif.services.DatasetIOService;
+import net.imglib2.cache.img.CellLoader;
+import net.imglib2.cache.img.DiskCachedCellImg;
+import net.imglib2.cache.img.DiskCachedCellImgFactory;
+import net.imglib2.cache.img.DiskCachedCellImgOptions;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import org.scijava.Context;
+import org.scijava.parallel.ParallelizationParadigm;
+
+public class SimpleExampleInDiskCachedCellImg
+{
+	public static void main( String... args ) throws InterruptedException
+	{
+
+		Context context = new Context();
+		DatasetIOService ioService = context.service( DatasetIOService.class );
+		try (ParallelizationParadigm paradigm = TestParadigm.localImageJServer( Config.getFijiExecutable(), context ))
+		{
+			final CellLoader< UnsignedByteType > loader = cell -> {
+				RotateSingleDataset.rotateSingleDataset( ioService, paradigm ); // failing
+				//ScriptEvalRemotely.run(paradigm); // working
+			};
+			DiskCachedCellImg< UnsignedByteType, ? > img = createCellImage( loader );
+			BdvFunctions.show( img, "title" ).setDisplayRange( 0, 1 );
+		}
+	}
+
+	private static DiskCachedCellImg< UnsignedByteType, ? > createCellImage( CellLoader< UnsignedByteType > loader )
+	{
+		long[] imageSize = { 100, 100, 100 };
+		int[] cellSize = { 50, 50, 50};
+		final DiskCachedCellImgOptions options = DiskCachedCellImgOptions.options().cellDimensions( cellSize );
+		final DiskCachedCellImgFactory< UnsignedByteType > factory = new DiskCachedCellImgFactory<>( new UnsignedByteType(), options );
+		return factory.create( imageSize, loader );
+	}
+}

--- a/src/test/java/test/SimpleExampleInDiskCachedCellImg.java
+++ b/src/test/java/test/SimpleExampleInDiskCachedCellImg.java
@@ -1,32 +1,37 @@
 package test;
 
-import bdv.util.BdvFunctions;
-import cz.it4i.parallel.TestParadigm;
 import io.scif.services.DatasetIOService;
+
 import net.imglib2.cache.img.CellLoader;
 import net.imglib2.cache.img.DiskCachedCellImg;
 import net.imglib2.cache.img.DiskCachedCellImgFactory;
 import net.imglib2.cache.img.DiskCachedCellImgOptions;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
+
 import org.scijava.Context;
 import org.scijava.parallel.ParallelizationParadigm;
 
+import bdv.util.BdvFunctions;
+import cz.it4i.parallel.TestParadigm;
+
 public class SimpleExampleInDiskCachedCellImg
 {
-	public static void main( String... args ) throws InterruptedException
+
+	public static void main(String... args) 
 	{
 
 		Context context = new Context();
 		DatasetIOService ioService = context.service( DatasetIOService.class );
-		try (ParallelizationParadigm paradigm = TestParadigm.localImageJServer( Config.getFijiExecutable(), context ))
-		{
-			final CellLoader< UnsignedByteType > loader = cell -> {
-				RotateSingleDataset.rotateSingleDataset( ioService, paradigm ); // failing
-				//ScriptEvalRemotely.run(paradigm); // working
-			};
-			DiskCachedCellImg< UnsignedByteType, ? > img = createCellImage( loader );
-			BdvFunctions.show( img, "title" ).setDisplayRange( 0, 1 );
-		}
+		ParallelizationParadigm paradigm = TestParadigm.localImageJServer(Config
+			.getFijiExecutable(), context);
+
+		final CellLoader<UnsignedByteType> loader = cell -> {
+			RotateSingleDataset.rotateSingleDataset(ioService, paradigm); // failing
+			// ScriptEvalRemotely.run(paradigm); // working
+		};
+		DiskCachedCellImg<UnsignedByteType, ?> img = createCellImage(loader);
+		BdvFunctions.show(img, "title").setDisplayRange(0, 1);
+		Runtime.getRuntime().addShutdownHook(new Thread(() -> paradigm.close()));
 	}
 
 	private static DiskCachedCellImg< UnsignedByteType, ? > createCellImage( CellLoader< UnsignedByteType > loader )


### PR DESCRIPTION
@kozusznik Please have a look into this: ```SimpleExampleInDiskCachedCellImg```

I try to use scijava-parallel with Labkit. When doing so I come across this problem.
Scijava-parallel cannot be used inside the ```CellLoader``` of a ```DiskCachedCellImg```.
I have no idea what causes this problem. Maybe you can find the bug.
It apparently is somehow related to the transfer of the ```Dataset``` to or from ImageJ server.

When you don't understand ```DiskCachedCellImg``` will find nice examples here:
https://github.com/imglib/imglib2-cache-examples/blob/master/src/main/java/net/imglib2/cache/example04/Example04.java
There's no way around ```DiskCachedCellImg``` in Labkit. It coordinates the clever view dependent
calculation of the segmentation that I need.

