### PR TITLE
Allow reuse job

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,33 +140,39 @@
 			<artifactId>imagej-server</artifactId>
 			<version>0.1.3-SNAPSHOT</version>
 			<exclusions>
-			<exclusion>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-log4j12</artifactId>
-			</exclusion>
-			<exclusion>
-				<groupId>org.slf4j</groupId>
-				<artifactId>jcl-over-slf4j</artifactId>
-			</exclusion>
-			<exclusion>
-				<groupId>org.slf4j</groupId>
-				<artifactId>jcl-over-slf4j</artifactId>
-			</exclusion>
-			<exclusion>
-				<groupId>org.slf4j</groupId>
-				<artifactId>log4j-over-slf4j</artifactId>
-			</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>jcl-over-slf4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>jcl-over-slf4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>log4j-over-slf4j</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>cz.it4i.fiji</groupId>
-			<artifactId>java-scpclient</artifactId>
-			<version>0.0.2-SNAPSHOT</version>
+			<artifactId>scp-java-client</artifactId>
+			<version>1.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>bigdataviewer-vistools</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.6</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 	<distributionManagement>
@@ -179,5 +185,5 @@
 			<url>https://artifactory.cs.vsb.cz/it4i/</url>
 		</snapshotRepository>
 	</distributionManagement>
-	
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,8 @@
 	<dependencies>
 		<dependency>
 			<groupId>cz.it4i.fiji</groupId>
-			<artifactId>haas-java-client</artifactId>
-			<version>0.0.8-SNAPSHOT</version>
+			<artifactId>heappe-java-client</artifactId>
+			<version>1.0.1</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<relativePath />
 	</parent>
 	<artifactId>scijava-parallel</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<name>SciJava Parallel</name>
 	<description>Parallelization framework for SciJava applications.</description>
 	<url>https://</url>

--- a/src/main/java/cz/it4i/parallel/ClusterJobLauncher.java
+++ b/src/main/java/cz/it4i/parallel/ClusterJobLauncher.java
@@ -36,7 +36,7 @@ public class ClusterJobLauncher implements Closeable {
 
 		private CompletableFuture<List<String>> nodesFuture;
 
-		public Job(String jobId) {
+		private Job(String jobId) {
 			super();
 			this.jobId = jobId;
 			nodesFuture = CompletableFuture.supplyAsync(() -> getNodesFromServer());
@@ -164,6 +164,11 @@ public class ClusterJobLauncher implements Closeable {
 					InputStream is = session.getStdout();
 					while (-1 != (readed = is.read(buffer))) {
 						outputStream.write(buffer, 0, readed);
+						try {
+							Thread.sleep(100);
+						}
+						catch (InterruptedException exc) {
+						}
 					}
 				}
 				catch (IOException exc) {

--- a/src/main/java/cz/it4i/parallel/ClusterJobLauncher.java
+++ b/src/main/java/cz/it4i/parallel/ClusterJobLauncher.java
@@ -112,7 +112,7 @@ public class ClusterJobLauncher implements Closeable {
 			}
 			while (!(!time.equals("0") && state.equals("R")));
 			new P_OutThread(System.out, "OU").start();
-			new P_OutThread(System.out, "ER").start();
+			new P_OutThread(System.err, "ER").start();
 		}
 
 		private List<String> getNodesFromServer() {

--- a/src/main/java/cz/it4i/parallel/ClusterJobLauncher.java
+++ b/src/main/java/cz/it4i/parallel/ClusterJobLauncher.java
@@ -26,6 +26,8 @@ public class ClusterJobLauncher implements Closeable {
 	private final static Logger log = LoggerFactory.getLogger(
 		ClusterJobLauncher.class);
 
+	private final static long REMOTE_CONSOLE_READ_TIMEOUT = 500;
+
 	public class Job {
 
 		/*
@@ -103,12 +105,7 @@ public class ClusterJobLauncher implements Closeable {
 				String[] tokens = result.split(" +");
 				state = tokens[4];
 				time = tokens[3];
-				try {
-					Thread.sleep(1000);
-				}
-				catch (InterruptedException exc) {
-					log.error("waiting", exc);
-				}
+				sleepForWhile(1000);
 			}
 			while (!(!time.equals("0") && state.equals("R")));
 			new P_OutThread(System.out, "OU").start();
@@ -164,11 +161,7 @@ public class ClusterJobLauncher implements Closeable {
 					InputStream is = session.getStdout();
 					while (-1 != (readed = is.read(buffer))) {
 						outputStream.write(buffer, 0, readed);
-						try {
-							Thread.sleep(100);
-						}
-						catch (InterruptedException exc) {
-						}
+						sleepForWhile(REMOTE_CONSOLE_READ_TIMEOUT);
 					}
 				}
 				catch (IOException exc) {
@@ -221,6 +214,13 @@ public class ClusterJobLauncher implements Closeable {
 // @formatter:on
 		client.executeCommand("rm " + fileName);
 		return result;
+	}
+
+	static private void sleepForWhile(long timeout) {
+		try {
+			Thread.sleep(timeout);
+		}
+		catch (InterruptedException exc) {}
 	}
 
 }

--- a/src/main/java/cz/it4i/parallel/HPCImageJServerRunner.java
+++ b/src/main/java/cz/it4i/parallel/HPCImageJServerRunner.java
@@ -44,8 +44,13 @@ public class HPCImageJServerRunner extends AbstractImageJServerRunner {
 				settings.getKeyFilePassword()));
 		final String arguments = AbstractImageJServerRunner.IMAGEJ_SERVER_PARAMETERS
 				.stream().collect( Collectors.joining( " " ) );
-		job = launcher.submit(settings.getRemoteDirectory(), settings.getCommand(), arguments,
-				settings.getNodes(), settings.getNcpus());
+		if (settings.getJobID() != null) {
+			job = launcher.getSubmittedJob(settings.getJobID());
+		}
+		else {
+			job = launcher.submit(settings.getRemoteDirectory(), settings
+				.getCommand(), arguments, settings.getNodes(), settings.getNcpus());
+		}
 		ports = job.createTunnels(8080, 8080);
 	}
 

--- a/src/main/java/cz/it4i/parallel/HPCSettings.java
+++ b/src/main/java/cz/it4i/parallel/HPCSettings.java
@@ -1,5 +1,7 @@
 package cz.it4i.parallel;
 
+import com.google.common.base.Strings;
+
 import java.io.File;
 
 import lombok.Builder;

--- a/src/main/java/cz/it4i/parallel/HPCSettings.java
+++ b/src/main/java/cz/it4i/parallel/HPCSettings.java
@@ -2,6 +2,12 @@ package cz.it4i.parallel;
 
 import java.io.File;
 
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+
+@Builder
 public class HPCSettings
 {
 	private final String host;
@@ -20,58 +26,8 @@ public class HPCSettings
 
 	private final int ncpus;
 
-	public HPCSettings(String host, String userName, File keyFile,
-			String keyFilePassword, String remoteDirectory, String command, int nodes,
-			int ncpus)
-	{
-		super();
-		this.host = host;
-		this.userName = userName;
-		this.keyFile = keyFile;
-		this.keyFilePassword = keyFilePassword;
-		this.remoteDirectory = remoteDirectory;
-		this.command = command;
-		this.nodes = nodes;
-		this.ncpus = ncpus;
-	}
+	private final String jobID;
 
-	public String getHost()
-	{
-		return host;
-	}
+	private final boolean shutdownJobAfterClose;
 
-	public String getUserName()
-	{
-		return userName;
-	}
-
-	public File getKeyFile()
-	{
-		return keyFile;
-	}
-
-	public String getKeyFilePassword()
-	{
-		return keyFilePassword;
-	}
-
-	public String getRemoteDirectory()
-	{
-		return remoteDirectory;
-	}
-
-	public String getCommand()
-	{
-		return command;
-	}
-
-	public int getNodes()
-	{
-		return nodes;
-	}
-
-	public int getNcpus()
-	{
-		return ncpus;
-	}
 }

--- a/src/main/java/cz/it4i/parallel/ui/HPCImageJServerRunnerWithUI.java
+++ b/src/main/java/cz/it4i/parallel/ui/HPCImageJServerRunnerWithUI.java
@@ -13,14 +13,21 @@ import org.scijava.Context;
 
 import cz.it4i.parallel.HPCImageJServerRunner;
 import cz.it4i.parallel.HPCSettings;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class HPCImageJServerRunnerWithUI extends HPCImageJServerRunner {
 
 	private JDialog dialog;
 	private JLabel label;
 
+	@Getter
+	final private boolean shutdownJob;
+
 	public HPCImageJServerRunnerWithUI(HPCSettings settings) {
 		super(settings);
+		shutdownJob = settings.isShutdownJobAfterClose();
 	}
 
 	@Override
@@ -48,6 +55,7 @@ public class HPCImageJServerRunnerWithUI extends HPCImageJServerRunner {
 
 	private void imageJServerRunning() {
 		dialog.setVisible(false);
+		log.info("job: " + getJob().getID() + " started.");
 	}
 
 	@Override
@@ -58,7 +66,7 @@ public class HPCImageJServerRunnerWithUI extends HPCImageJServerRunner {
 		dialog.setVisible(false);
 	}
 
-	public static HPCImageJServerRunner gui(Context context) {
+	public static HPCImageJServerRunnerWithUI gui(Context context) {
 		return new HPCImageJServerRunnerWithUI(HPCSettingsGui.showDialog(context));
 	}
 }

--- a/src/main/java/cz/it4i/parallel/ui/HPCImageJServerRunnerWithUI.java
+++ b/src/main/java/cz/it4i/parallel/ui/HPCImageJServerRunnerWithUI.java
@@ -55,7 +55,8 @@ public class HPCImageJServerRunnerWithUI extends HPCImageJServerRunner {
 
 	private void imageJServerRunning() {
 		dialog.setVisible(false);
-		log.info("job: " + getJob().getID() + " started.");
+		log.info("job: " + getJob().getID() + " started on hosts: " + getJob()
+			.getNodes());
 	}
 
 	@Override

--- a/src/main/java/cz/it4i/parallel/ui/HPCSettingsGui.java
+++ b/src/main/java/cz/it4i/parallel/ui/HPCSettingsGui.java
@@ -46,13 +46,22 @@ public class HPCSettingsGui implements Command {
 	@Parameter(style = TextWidget.FIELD_STYLE, label = "Number of cpus per node")
 	private int ncpus;
 
+	@Parameter(style = TextWidget.FIELD_STYLE, label = "Running job ID")
+	private String jobID;
+
+	@Parameter(style = TextWidget.FIELD_STYLE,
+		label = "Shutdown job when application finishes.")
+	private boolean shutdownJobAfterClose;
+
 	@Parameter(type = ItemIO.OUTPUT)
 	private HPCSettings settings;
 
 	@Override
 	public void run() {
-		settings = new HPCSettings(host, userName, keyFile, keyFilePassword,
-			remoteDirectory, command, nodes, ncpus);
+		settings = HPCSettings.builder().host(host).userName(userName).keyFile(
+			keyFile).keyFilePassword(keyFilePassword).remoteDirectory(remoteDirectory)
+			.command(command).nodes(nodes).ncpus(ncpus).jobID(jobID)
+			.shutdownJobAfterClose(shutdownJobAfterClose).build();
 	}
 
 	public static HPCSettings showDialog(Context context) {

--- a/src/main/java/cz/it4i/parallel/ui/HPCSettingsGui.java
+++ b/src/main/java/cz/it4i/parallel/ui/HPCSettingsGui.java
@@ -1,6 +1,8 @@
 
 package cz.it4i.parallel.ui;
 
+import com.google.common.base.Strings;
+
 import java.io.File;
 import java.util.concurrent.ExecutionException;
 
@@ -60,7 +62,8 @@ public class HPCSettingsGui implements Command {
 	public void run() {
 		settings = HPCSettings.builder().host(host).userName(userName).keyFile(
 			keyFile).keyFilePassword(keyFilePassword).remoteDirectory(remoteDirectory)
-			.command(command).nodes(nodes).ncpus(ncpus).jobID(jobID)
+			.command(command).nodes(nodes).ncpus(ncpus).jobID(Strings.emptyToNull(
+				jobID))
 			.shutdownJobAfterClose(shutdownJobAfterClose).build();
 	}
 


### PR DESCRIPTION
Main issue for discussion is using of Lombok tool - https://projectlombok.org/.
It is used in software industry due the fact that it eliminates using of boiler plate code.
Code that uses lombok should be automatically transformed to Java code without lombok annotation.
It is necessary to install lombok tool into eclipse IDE before opening project - https://projectlombok.org/setup/eclipse.