### PR TITLE
Update to SciJava Maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
 
 	<mailingLists>
 		<mailingList>
-			<name>ImageJ Forum</name>
-			<archive>http://forum.imagej.net/</archive>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/tags/scijava-parallel</archive>
 		</mailingList>
 	</mailingLists>
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,16 +67,16 @@
 		<license.licenseName>bsd_2</license.licenseName>
 		<license.copyrightOwners>SciJava developers.</license.copyrightOwners>
 
-		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
-		<releaseProfiles>deploy-to-imagej</releaseProfiles>
+		<!-- NB: Deploy releases to the SciJava Maven repository. -->
+		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 
 		<!-- TODO: Find out what is this for -->
 	</properties>
 
 	<repositories>
 		<repository>
-			<id>imagej.public</id>
-			<url>http://maven.imagej.net/content/groups/public</url>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 		<repository>
 			<id>it4i</id>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 	</scm>
 	<issueManagement>
 		<system>GitHub Issues</system>
-		<url>http://github.com/imagej/imagej-server</url>
+		<url>https://github.com/imagej/imagej-server</url>
 	</issueManagement>
 	<ciManagement>
 		<system>Travis CI</system>


### PR DESCRIPTION
The maven.imagej.net repository became maven.scijava.org. This PR addresses that change, along with some other minor POM updates and improvements.